### PR TITLE
chore: bump formatting and build tool dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,20 +11,20 @@
 		"cspell": "cspell **",
 		"format": "prettier --write './src/**/*.{ts,svelte,astro}' "
 	},
-	"dependencies": {
-		"@astrojs/check": "^0.2.0",
-		"@astrojs/svelte": "^4.0.2",
-		"@astrojs/tailwind": "^5.0.0",
-		"astro": "^3.0.12",
-		"prettier": "^3.0.3",
-		"prettier-plugin-astro": "^0.12.0",
-		"prettier-plugin-svelte": "^3.0.3",
-		"prettier-plugin-tailwindcss": "^0.5.4",
-		"svelte": "^4.0.0",
-		"tailwindcss": "^3.0.24",
-		"typescript": "^5.2.2"
-	},
-	"devDependencies": {
-		"cspell": "^7.3.2"
-	}
+        "dependencies": {
+                "@astrojs/check": "^0.2.0",
+                "@astrojs/svelte": "^4.0.2",
+                "@astrojs/tailwind": "^5.0.0",
+                "astro": "^3.0.12",
+                "prettier": "^3.2.5",
+                "prettier-plugin-astro": "^0.13.0",
+                "prettier-plugin-svelte": "^3.1.2",
+                "prettier-plugin-tailwindcss": "^0.5.13",
+                "svelte": "^4.2.9",
+                "tailwindcss": "^3.4.1",
+                "typescript": "^5.4.5"
+        },
+        "devDependencies": {
+                "cspell": "^8.3.2"
+        }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,7 +1509,6 @@ chokidar@^3.5.3:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -1776,30 +1775,6 @@ cspell-trie-lib@7.3.5:
     "@cspell/cspell-pipe" "7.3.5"
     "@cspell/cspell-types" "7.3.5"
     gensequence "^5.0.2"
-
-cspell@^7.3.2:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/cspell/-/cspell-7.3.5.tgz#cef8290097009f2b80627cf1c125ac8ff6dce6d0"
-  integrity sha512-5CcFqHpi5VoJUvdnmC1bhg2leHTaRlj+ARjt+c5clEgiK9FOv0StdlVKCY4V5R96JEBfnsc3SSaNnCu+6oWAVA==
-  dependencies:
-    "@cspell/cspell-json-reporter" "7.3.5"
-    "@cspell/cspell-pipe" "7.3.5"
-    "@cspell/cspell-types" "7.3.5"
-    "@cspell/dynamic-import" "7.3.5"
-    chalk "^5.3.0"
-    chalk-template "^1.1.0"
-    commander "^11.0.0"
-    cspell-gitignore "7.3.5"
-    cspell-glob "7.3.5"
-    cspell-io "7.3.5"
-    cspell-lib "7.3.5"
-    fast-glob "^3.3.1"
-    fast-json-stable-stringify "^2.1.0"
-    file-entry-cache "^6.0.1"
-    get-stdin "^9.0.0"
-    semver "^7.5.4"
-    strip-ansi "^7.1.0"
-    vscode-uri "^3.0.7"
 
 css-tree@^2.3.1:
   version "2.3.1"
@@ -3588,30 +3563,6 @@ preferred-pm@^3.1.2:
     path-exists "^4.0.0"
     which-pm "2.0.0"
 
-prettier-plugin-astro@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-astro/-/prettier-plugin-astro-0.12.0.tgz#4faf0d0fcc7ca005668917109f399a548473a6fd"
-  integrity sha512-8E+9YQR6/5CPZJs8XsfBw579zrwZkc0Wb7x0fRVm/51JC8Iys4lBw4ecV8fHwpbQnzve86TUa4fJ08BJzqfWnA==
-  dependencies:
-    "@astrojs/compiler" "^1.5.5"
-    prettier "^3.0.0"
-    sass-formatter "^0.7.6"
-
-prettier-plugin-svelte@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-3.0.3.tgz#a823295167f27dc71a4462ee6cb3da9f3f5ca2ea"
-  integrity sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==
-
-prettier-plugin-tailwindcss@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.4.tgz#ebfacbcb90e2ca1df671ffe4083e99f81d72040d"
-  integrity sha512-QZzzB1bID6qPsKHTeA9qPo1APmmxfFrA5DD3LQ+vbTmAnY40eJI7t9Q1ocqel2EKMWNPLJqdTDWZj1hKYgqSgg==
-
-prettier@^3.0.0, prettier@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
-  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
-
 prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
@@ -4146,53 +4097,6 @@ svelte2tsx@^0.6.20:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"
 
-svelte@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.2.0.tgz#0e4304c15524450b22fba02516eb72efbd8847b6"
-  integrity sha512-kVsdPjDbLrv74SmLSUzAsBGquMs4MPgWGkGLpH+PjOYnFOziAvENVzgJmyOCV2gntxE32aNm8/sqNKD6LbIpeQ==
-  dependencies:
-    "@ampproject/remapping" "^2.2.1"
-    "@jridgewell/sourcemap-codec" "^1.4.15"
-    "@jridgewell/trace-mapping" "^0.3.18"
-    acorn "^8.9.0"
-    aria-query "^5.3.0"
-    axobject-query "^3.2.1"
-    code-red "^1.0.3"
-    css-tree "^2.3.1"
-    estree-walker "^3.0.3"
-    is-reference "^3.0.1"
-    locate-character "^3.0.0"
-    magic-string "^0.30.0"
-    periscopic "^3.1.0"
-
-tailwindcss@^3.0.24:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.3.tgz#90da807393a2859189e48e9e7000e6880a736daf"
-  integrity sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==
-  dependencies:
-    "@alloc/quick-lru" "^5.2.0"
-    arg "^5.0.2"
-    chokidar "^3.5.3"
-    didyoumean "^1.2.2"
-    dlv "^1.1.3"
-    fast-glob "^3.2.12"
-    glob-parent "^6.0.2"
-    is-glob "^4.0.3"
-    jiti "^1.18.2"
-    lilconfig "^2.1.0"
-    micromatch "^4.0.5"
-    normalize-path "^3.0.0"
-    object-hash "^3.0.0"
-    picocolors "^1.0.0"
-    postcss "^8.4.23"
-    postcss-import "^15.1.0"
-    postcss-js "^4.0.1"
-    postcss-load-config "^4.0.1"
-    postcss-nested "^6.0.1"
-    postcss-selector-parser "^6.0.11"
-    resolve "^1.22.2"
-    sucrase "^3.32.0"
-
 tar-fs@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
@@ -4335,11 +4239,6 @@ typescript-auto-import-cache@^0.3.0:
   integrity sha512-Rq6/q4O9iyqUdjvOoyas7x/Qf9nWUMeqpP3YeTaLA+uECgfy5wOhfOS+SW/+fZ/uI/ZcKaf+2/ZhFzXh8xfofQ==
   dependencies:
     semver "^7.3.8"
-
-typescript@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 undici@^5.23.0:
   version "5.24.0"


### PR DESCRIPTION
## Summary
- bump Prettier, Prettier plugins, Svelte, Tailwind CSS, TypeScript, and cspell to newer releases
- prune outdated lockfile entries so Yarn can resolve the refreshed dependency ranges on install

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e060a651d083309abcfce837780755