### PR TITLE
Fix SectionType definition to use value import

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-import type { SECTIONS } from '@constants/index'
-
-export type SectionType = (typeof SECTIONS)[number]
+export type SectionType = (typeof import('@constants/index').SECTIONS)[number]
 
 export type ThemeType = 'dark' | 'light'


### PR DESCRIPTION
## Summary
- update the SectionType alias to reference SECTIONS via an inline import so typeof has a value

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e06714f17883308a0956fcae04b99e